### PR TITLE
Implement configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This project uses [websocket-client](https://github.com/liris/websocket-client).
 
 Python program for producing text logs from IRCCloud's stream and backlog.
 
-Currently saves log names as base64, because, come on, if you need the filenames, you can parse the name. Nicknames can contain characters that don't work in filenames, and converting the filename to base64 removes that problem.
+Currently saves log names as the actual name on the IRC network, except with / (slash) replaced with _ (underscore).
 
 Authentication and backlog-loading issues solved by moving to websocket instead of https. Many thanks to @l1am9111 for doing this.
 

--- a/logger.py
+++ b/logger.py
@@ -6,6 +6,7 @@ import errno
 import sys
 import base64
 import websocket
+import string
 
 delay = 0.0
 idleinterval = 0
@@ -361,11 +362,11 @@ def log(msg, server="IRCCloud", channel="#feedback",
             if exception.errno != errno.EEXIST:
                 raise
     try:
-        channelb64 = base64.urlsafe_b64encode(uni2str(channel))
-        make_sure_path_exists("logs" + os.sep + server + os.sep + channelb64)
-        # logs/server/channel(b64)/date.log
+        channel_fssafe = string.replace(uni2str(channel), "/", "_")
+        make_sure_path_exists("logs" + os.sep + server + os.sep + channel_fssafe)
+        # logs/server/channel_fssafe/date.log
         with open("logs" + os.sep + server +
-                  os.sep + channelb64 + os.sep +
+                  os.sep + channel_fssafe + os.sep +
                   date + ".log", "a+") as f:
             f.write(uni2str(msg) + "\n")
         print "(S)", date, server + ":" + uni2str(channel), msg


### PR DESCRIPTION
Switch to using a JSON configuration file to store authentication information (for now, can add other configuration later) rather than specifying on the command line.
